### PR TITLE
feat(mp): animated turn transitions + header score anim + puzzle fixes

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -142,6 +142,9 @@
 
     <AchievementToast />
 
+    <!-- Multiplayer turn-transition banner -->
+    <TurnBanner />
+
     <div class="hidden grid-cols-3 grid-cols-4">Tailwind forced classes</div>
   </div>
 </template>
@@ -154,6 +157,7 @@ import GameOver from './components/GameOver.vue'
 import LevelSelect from './components/LevelSelect.vue'
 import ProfilePanel from './components/ProfilePanel.vue'
 import AchievementToast from './components/AchievementToast.vue'
+import TurnBanner from './components/TurnBanner.vue'
 import { useGameStore } from './stores/gameStore'
 import { GameMode as GameModeEnum } from './enums/GameMode'
 import { GameVariant } from './enums/GameVariant'

--- a/src/components/GameBoard.vue
+++ b/src/components/GameBoard.vue
@@ -20,14 +20,15 @@
 
     <header id="players-container" class="players-header">
       <div v-for="(_, index) in playerCount" :key="index"
-           :class="['player-chip', { active: currentPlayer === index }]">
+           :data-player-chip="index"
+           :class="['player-chip', { active: currentPlayer === index, 'score-bump': bumpFlags[index] }]">
         <div class="player-avatar">
           <i v-if="isPlayerAI(index)" class="fas fa-robot"></i>
           <template v-else>{{ getPlayerName(index).charAt(0).toUpperCase() }}</template>
         </div>
         <div class="player-meta">
           <div class="player-name">{{ getPlayerName(index) }}</div>
-          <div class="player-score">{{ getPlayerScore(index) }}</div>
+          <div class="player-score">{{ displayScore(index) }}</div>
         </div>
       </div>
     </header>
@@ -280,7 +281,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, onMounted, onUnmounted, watch } from 'vue'
+import { computed, ref, onMounted, onUnmounted, watch, nextTick } from 'vue'
 import { useGameStore } from '../stores/gameStore'
 import { usePeerStore } from '../stores/peerStore'
 import { usePlayerProfileStore } from '../stores/playerProfileStore'
@@ -306,6 +307,7 @@ import {
   showBonusTurnGlow,
   showScoreBreakdown,
   showGoalMet,
+  showPlayerScorePop,
 } from '../utils/cellAnimations'
 
 const emit = defineEmits<{
@@ -474,6 +476,67 @@ const toggleHold = (index: number) => {
 const getPlayerScore = (index: number): number => {
   return currentGame.value?.getPlayerScore(index) || 0;
 }
+
+// --- Animated header-chip scores -----------------------------------------
+// displayScores holds the value actually rendered in each chip. When a
+// player's real total climbs we tween the displayed number up, pulse the
+// chip, and float a "+N" above it. Decreases (restart) snap without anim.
+const displayScores = ref<number[]>([]);
+const bumpFlags = ref<boolean[]>([]);
+const prefersReducedMotion = typeof window !== 'undefined' && window.matchMedia
+  ? window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  : false;
+const scoreTweenHandles: Record<number, number> = {};
+const scoreBumpHandles: Record<number, ReturnType<typeof setTimeout>> = {};
+
+// Reactive snapshot of every player's real total; drives the watcher below.
+const realScores = computed(() =>
+  Array.from({ length: playerCount.value }, (_, i) => getPlayerScore(i))
+);
+
+function tweenScore(i: number, from: number, to: number): void {
+  if (scoreTweenHandles[i]) cancelAnimationFrame(scoreTweenHandles[i]);
+  if (prefersReducedMotion) { displayScores.value[i] = to; return; }
+  const dur = 600;
+  const start = performance.now();
+  const step = (now: number) => {
+    const t = Math.min(1, (now - start) / dur);
+    const eased = 1 - Math.pow(1 - t, 3);
+    displayScores.value[i] = Math.round(from + (to - from) * eased);
+    if (t < 1) scoreTweenHandles[i] = requestAnimationFrame(step);
+    else displayScores.value[i] = to;
+  };
+  scoreTweenHandles[i] = requestAnimationFrame(step);
+}
+
+function bumpChip(i: number): void {
+  bumpFlags.value[i] = false;
+  void nextTick(() => { bumpFlags.value[i] = true; });
+  if (scoreBumpHandles[i]) clearTimeout(scoreBumpHandles[i]);
+  scoreBumpHandles[i] = setTimeout(() => { bumpFlags.value[i] = false; }, 600);
+}
+
+watch(realScores, (next, prev) => {
+  // Initial fill or roster change: sync without animating.
+  if (!prev || prev.length !== next.length) {
+    displayScores.value = [...next];
+    bumpFlags.value = next.map(() => false);
+    return;
+  }
+  next.forEach((val, i) => {
+    const shown = displayScores.value[i] ?? val;
+    if (val > shown) {
+      tweenScore(i, shown, val);
+      bumpChip(i);
+      showPlayerScorePop(i, val - shown);
+    } else if (val !== shown) {
+      displayScores.value[i] = val; // decrease / reset — no anim
+    }
+  });
+}, { immediate: true });
+
+const displayScore = (index: number): number =>
+  displayScores.value[index] ?? getPlayerScore(index);
 
 const getScoreDisplay = (category: Categories): string => {
   // If category is already selected, just return the stored score

--- a/src/components/TurnBanner.vue
+++ b/src/components/TurnBanner.vue
@@ -1,0 +1,101 @@
+<template>
+  <!-- Mounted/unmounted together by the store (turnBanner ref). Both the
+       dim backdrop and the banner run a single one-shot CSS keyframe whose
+       duration must match BANNER_TOTAL_MS in gameStore.ts. -->
+  <div v-if="banner" class="turn-banner-root" aria-hidden="false">
+    <div class="turn-banner-backdrop"></div>
+    <div class="turn-banner" role="status" aria-live="polite">
+      <i class="fas fa-play turn-banner-icon"></i>
+      <span class="turn-banner-text">{{ banner.text }}</span>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { storeToRefs } from 'pinia'
+import { useGameStore } from '../stores/gameStore'
+
+const gameStore = useGameStore()
+const { turnBanner: banner } = storeToRefs(gameStore)
+</script>
+
+<style scoped>
+.turn-banner-root {
+  position: fixed;
+  inset: 0;
+  z-index: 958;
+  pointer-events: none;
+}
+
+/* Dim + blur the whole board so the banner pops instead of blending in. */
+.turn-banner-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(2, 6, 23, 0.62);
+  backdrop-filter: blur(3px);
+  -webkit-backdrop-filter: blur(3px);
+  animation: turnBannerBackdrop 2s ease forwards;
+}
+
+.turn-banner {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.7rem;
+  padding: 0.95rem 1.6rem;
+  border-radius: 999px;
+  white-space: nowrap;
+  background: linear-gradient(100deg, var(--accent, #c026d3) 0%, var(--accent-soft, #e879f9) 100%);
+  color: #fff;
+  font-weight: 900;
+  letter-spacing: 0.01em;
+  text-shadow: 0 2px 8px rgba(0, 0, 0, 0.5);
+  box-shadow:
+    0 10px 40px -6px rgba(0, 0, 0, 0.6),
+    0 0 0 2px rgba(255, 255, 255, 0.18) inset,
+    0 0 36px -2px var(--accent-soft, rgba(232, 121, 249, 0.7));
+  animation: turnBannerSweep 2s cubic-bezier(0.16, 0.84, 0.3, 1) forwards;
+}
+.turn-banner-icon {
+  font-size: 1.15rem;
+  opacity: 0.95;
+}
+.turn-banner-text {
+  font-size: 1.55rem;
+}
+
+/* Slide in from the left, pause at dead center, exit to the right. The long
+   center plateau (18%→78%) is the readable beat the user asked for. */
+@keyframes turnBannerSweep {
+  0%   { transform: translate(calc(-50% - 78vw), -50%) scale(0.92); opacity: 0; }
+  18%  { transform: translate(-50%, -50%) scale(1); opacity: 1; }
+  78%  { transform: translate(-50%, -50%) scale(1); opacity: 1; }
+  100% { transform: translate(calc(-50% + 78vw), -50%) scale(0.92); opacity: 0; }
+}
+@keyframes turnBannerBackdrop {
+  0%   { opacity: 0; }
+  14%  { opacity: 1; }
+  80%  { opacity: 1; }
+  100% { opacity: 0; }
+}
+
+/* Reduced motion: no horizontal travel — fade/scale gently at center. */
+@media (prefers-reduced-motion: reduce) {
+  .turn-banner {
+    animation: turnBannerFadeRM 2s ease forwards;
+  }
+  @keyframes turnBannerFadeRM {
+    0%   { transform: translate(-50%, -50%) scale(0.98); opacity: 0; }
+    14%  { transform: translate(-50%, -50%) scale(1); opacity: 1; }
+    82%  { transform: translate(-50%, -50%) scale(1); opacity: 1; }
+    100% { transform: translate(-50%, -50%) scale(1); opacity: 0; }
+  }
+  .turn-banner-backdrop {
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+  }
+}
+</style>

--- a/src/controllers/AIController.ts
+++ b/src/controllers/AIController.ts
@@ -52,13 +52,21 @@ export class AIController implements PlayerController {
 
     private pickCategory(category: Categories): void {
         const game = useGameStore();
-        game.applySelectCategory(category);
+        const { bonusTurnQueued } = game.applySelectCategory(category);
 
         setTimeout(() => {
             const yahtzee = game.currentGame;
             if (!yahtzee) return;
             if (yahtzee.isGameOver) {
                 game.endGame();
+                return;
+            }
+            // Double Category granted a bonus turn — take it (same player,
+            // fresh rolls) instead of advancing. The strategy pursues the
+            // bonus category on the replay. Leaving this unhandled stranded
+            // pendingBonusCategory on the AI's engine.
+            if (bonusTurnQueued) {
+                game.startBonusTurn();
                 return;
             }
             // nextPlayer fires onTurnStart on the new current player. If

--- a/src/stores/gameStore.ts
+++ b/src/stores/gameStore.ts
@@ -57,6 +57,22 @@ const DAILY_STORAGE_KEY = 'puzzleDaily';
 const ACTION_PHASE_MS = 30_000;
 const MUSTPICK_PHASE_MS = 10_000;
 const TIMER_CHECK_MS = 250;
+
+// ---- Turn-transition banner (multiplayer hand-off) -----------------------
+// After a player scores we let the score-cell flight finish, sweep a banner
+// announcing the next player, then hand over control. The settle values track
+// showScoreCellFlight's tail so the banner lands just as it ends.
+// How long the banner element stays mounted. MUST match the CSS keyframe
+// duration in TurnBanner.vue (turnBannerSweep / turnBannerBackdrop = 2s),
+// which itself sweeps in → holds at center → sweeps out.
+const BANNER_TOTAL_MS = 2000;
+// Point during the banner at which the scorecard is flipped to the next player.
+// Must land while the dim backdrop is fully opaque (≈14%–80% of BANNER_TOTAL_MS
+// per TurnBanner.vue) so the switch is hidden, then revealed as the banner exits.
+const BANNER_REVEAL_MS = 1150;
+const SCORE_SETTLE_NORMAL_MS = 1700; // showScoreCellFlight tail
+const SCORE_SETTLE_YAHTZEE_MS = 2700;
+const SCORE_SETTLE_ZERO_MS = 900;
 // The raw interval handle lives outside reactive Pinia state so the 4Hz
 // expiry check doesn't churn reactivity. The reactive countdown the UI binds
 // to is game.turnTimer.deadline, which only changes on phase transitions/resets.
@@ -163,6 +179,15 @@ export const useGameStore = defineStore('game', {
     // applySelectCategory on the next Yahtzee selection. Survives turn
     // boundaries until used.
     pendingLuckyCharm: false,
+
+    // Turn-transition banner (multiplayer hand-off). turnTransitionActive
+    // gates human input for the whole sequence (wait-for-score-anim → banner
+    // sweep). turnBanner is non-null only while the banner element renders.
+    turnTransitionActive: false,
+    turnBanner: null as { text: string } | null,
+    // Timestamp (ms) when the most recent score animation finishes; the
+    // banner waits for this so it lands AFTER the score-cell flight.
+    scoreAnimationEndsAt: 0,
   }),
 
   getters: {
@@ -372,11 +397,21 @@ export const useGameStore = defineStore('game', {
       const puzzleEngine = this.game.getPuzzleEngine();
       const isBonusTurnApply = puzzleEngine?.hasPendingBonusFor(category) ?? false;
 
+      // Puzzle veto (e.g., Ice Block on this category). Enforced even on the
+      // bonus path so a blocked cell can NEVER be scored — a stale or
+      // mismatched pending bonus must not be able to slip past an Ice Block.
+      if (puzzleEngine && !puzzleEngine.canScore(category)) return result;
+
+      // A queued Double Category bonus that gets abandoned by scoring a
+      // DIFFERENT category is forfeited: clear it so the pending state can't
+      // dangle into later turns (an AI that ignores its bonus turn used to
+      // strand this, and the stale flag bypassed vetoes above).
+      if (puzzleEngine && !isBonusTurnApply && puzzleEngine.getPendingBonusCategory() !== null) {
+        puzzleEngine.consumePendingBonusCategory();
+      }
+
       // Reject double-scoring unless we're applying the Double Category bonus.
       if (this.game.isCategorySelected(category) && !isBonusTurnApply) return result;
-
-      // Puzzle veto (e.g., Ice Block on this category).
-      if (puzzleEngine && !isBonusTurnApply && !puzzleEngine.canScore(category)) return result;
 
       const dice = this.game.dice();
       // Lucky Charm consumable: substitutes a Yahtzee raw score (50) when
@@ -400,9 +435,11 @@ export const useGameStore = defineStore('game', {
 
         if (transformedScore > 0) {
           showScoreCellFlight(category, transformedScore);
+          this.scoreAnimationEndsAt = Date.now() + SCORE_SETTLE_NORMAL_MS;
           this.playSoundEffect?.(SoundEffects.Score);
         } else {
           showScoreZeroChip(category);
+          this.scoreAnimationEndsAt = Date.now() + SCORE_SETTLE_ZERO_MS;
           this.playSoundEffect?.(SoundEffects.NoScore);
         }
 
@@ -449,14 +486,17 @@ export const useGameStore = defineStore('game', {
           // chain cleanly.
           showScoreCellFlight(category, transformedScore);
           window.setTimeout(() => showYahtzeeAnimation(), 850);
+          this.scoreAnimationEndsAt = Date.now() + SCORE_SETTLE_YAHTZEE_MS;
           this.playSoundEffect?.(SoundEffects.Yahtzee);
           this.yahtzeesThisGame += 1
         } else {
           showScoreCellFlight(category, transformedScore);
+          this.scoreAnimationEndsAt = Date.now() + SCORE_SETTLE_NORMAL_MS;
           this.playSoundEffect?.(SoundEffects.Score);
         }
       } else {
         showScoreZeroChip(category);
+        this.scoreAnimationEndsAt = Date.now() + SCORE_SETTLE_ZERO_MS;
         this.playSoundEffect?.(SoundEffects.NoScore);
       }
       // Count bonus-Yahtzees too — the dice-match path above sets
@@ -472,20 +512,20 @@ export const useGameStore = defineStore('game', {
     //    inside the controller for the seat that owns the action.
 
     rollDice() {
-      if (!this.game) return;
+      if (!this.game || this.turnTransitionActive) return;
       // Online MP: only act on your own seat's turn.
       if (this.gameMode === GameMode.OnlineMultiPlayer && !this.isLocalSeatActive) return;
       this.game.players[this.game.currentPlayer].controller.requestRoll();
     },
 
     toggleHold(index: number) {
-      if (!this.game || this.game.newRoll) return;
+      if (!this.game || this.game.newRoll || this.turnTransitionActive) return;
       if (this.gameMode === GameMode.OnlineMultiPlayer && !this.isLocalSeatActive) return;
       this.game.players[this.game.currentPlayer].controller.requestHold(index);
     },
 
     selectCategory(category: Categories) {
-      if (!this.game || this.game.newRoll) return;
+      if (!this.game || this.game.newRoll || this.turnTransitionActive) return;
       if (this.gameMode === GameMode.OnlineMultiPlayer && !this.isLocalSeatActive) return;
       const puzzleEngine = this.game.getPuzzleEngine();
       const pendingBonus = puzzleEngine?.getPendingBonusCategory() ?? null;
@@ -570,13 +610,22 @@ export const useGameStore = defineStore('game', {
             if (data.category === Categories.Yahtzee && data.score > 0) {
               showScoreCellFlight(data.category, data.score);
               window.setTimeout(() => showYahtzeeAnimation(), 850);
+              this.scoreAnimationEndsAt = Date.now() + SCORE_SETTLE_YAHTZEE_MS;
               this.playSoundEffect?.(SoundEffects.Yahtzee);
             } else if (data.score > 0) {
               showScoreCellFlight(data.category, data.score);
+              this.scoreAnimationEndsAt = Date.now() + SCORE_SETTLE_NORMAL_MS;
               this.playSoundEffect?.(SoundEffects.Score);
             } else {
               showScoreZeroChip(data.category);
+              this.scoreAnimationEndsAt = Date.now() + SCORE_SETTLE_ZERO_MS;
               this.playSoundEffect?.(SoundEffects.NoScore);
+            }
+            // The preceding gameState already advanced currentPlayer; sweep
+            // the banner after the score flight settles. Client owns no
+            // turn-start/timer, so no onDone.
+            if (this.game) {
+              this.showTurnTransition(this.turnBannerText(this.game.currentPlayer));
             }
           }
           break;
@@ -695,29 +744,108 @@ export const useGameStore = defineStore('game', {
     // decides when to call this; broadcasting is the controller's job.
     nextPlayer() {
       if (!this.game) return;
-      // Puzzle modifiers may relocate or expire at end of turn (Flying
-      // Multiplier moves here; Hot Potato fuse can force-burn a slot).
-      // Fire this before advancing so the next player sees the updated
-      // board.
-      this.game.getPuzzleEngine()?.onTurnEnd();
-      // Hot Potato fuse expiry can fill the last remaining slot and end
-      // the game from inside onTurnEnd. Surface that immediately so the
-      // GameOver screen renders.
-      if (this.game.isGameOver) {
-        this.endGame();
+      const count = this.game.getPlayerCount();
+      const isOnline = this.gameMode === GameMode.OnlineMultiPlayer;
+
+      // Hand control to whoever is current: notify its controller (Local human
+      // / remote peer are no-ops; AIController starts its turn here) and arm the
+      // fresh clock (host-only / online-only).
+      const handControl = () => {
+        if (!this.game) return;
+        this.game.players[this.game.currentPlayer]?.controller.onTurnStart();
+        this.startTurnTimer();
+      };
+
+      // End-of-turn modifier effects on the FINISHING player's engine (Flying
+      // Multiplier relocates; Hot Potato fuse ticks; Looping rotates). Returns
+      // true if a Hot Potato fuse expiry ended the game. Local MP / vs-AI defer
+      // this into the banner (onReveal) so the relocation animations play hidden
+      // behind the dim backdrop instead of jumping the instant you score; every
+      // other path runs it now, up front.
+      const runTurnEnd = (): boolean => {
+        if (!this.game) return true;
+        this.game.getPuzzleEngine()?.onTurnEnd();
+        if (this.game.isGameOver) {
+          this.endGame();
+          return true;
+        }
+        return false;
+      };
+      const deferTurnEnd = count > 1 && !isOnline;
+      if (!deferTurnEnd && runTurnEnd()) return;
+
+      // Single-player: no hand-off, advance and start immediately as before.
+      if (count <= 1) {
+        this.game.nextPlayer();
+        this.game.rollsLeft = 2;
+        this.game.newRoll = true;
+        handControl();
         return;
       }
-      this.game.nextPlayer();
-      this.game.rollsLeft = 2;
-      this.game.newRoll = true;
-      if (this.gameMode === GameMode.OnlineMultiPlayer) {
+
+      // Online MP keeps the synchronous advance — the controller broadcasts the
+      // advanced gameState right after this returns. The banner only gates when
+      // the next player actually gets control.
+      if (isOnline) {
+        this.game.nextPlayer();
+        this.game.rollsLeft = 2;
+        this.game.newRoll = true;
         this.game.forceDiceReset();
+        this.showTurnTransition(this.turnBannerText(this.game.currentPlayer), {
+          onDone: handControl,
+        });
+        return;
       }
-      // Notify the new current player's controller. Local human / remote
-      // peer are no-ops; AIController starts its turn from here.
-      this.game.players[this.game.currentPlayer]?.controller.onTurnStart()
-      // Fresh 30s clock for the new player (host-only / online-only).
-      this.startTurnTimer()
+
+      // Local MP / vs-AI: keep the finishing player's scorecard on screen through
+      // the score animation + banner so the upper-score progression is visible,
+      // then run the deferred end-of-turn effects + advance under the banner's
+      // dim backdrop. The finishing player is still current during onReveal, so
+      // relocation animations anchor to the correct board.
+      const nextIdx = (this.game.currentPlayer + 1) % count;
+      this.showTurnTransition(this.turnBannerText(nextIdx), {
+        onReveal: () => {
+          if (runTurnEnd()) return;
+          if (!this.game) return;
+          this.game.nextPlayer();
+          this.game.rollsLeft = 2;
+          this.game.newRoll = true;
+        },
+        onDone: handControl,
+      });
+    },
+
+    // Builds the banner label for a seat. Online shows "Your turn" for the
+    // local seat (mirrors GameBoard's isMyTurn); everyone else is named.
+    turnBannerText(idx: number): string {
+      const name = this.game?.players[idx]?.name ?? 'Player';
+      if (this.gameMode === GameMode.OnlineMultiPlayer) {
+        const isYou = (idx === 0) === usePeerStore().isHost;
+        if (isYou) return 'Your turn';
+      }
+      return `${name}'s turn`;
+    },
+
+    // Gates input, waits for the in-flight score animation to finish, sweeps
+    // the banner, then runs onDone (the control hand-off). Not awaited by
+    // callers — the synchronous state advance has already happened, so any
+    // host broadcast after nextPlayer() still reflects the new player.
+    async showTurnTransition(
+      text: string,
+      opts: { onReveal?: () => void; onDone?: () => void } = {},
+    ) {
+      this.turnTransitionActive = true;
+      const wait = Math.max(0, this.scoreAnimationEndsAt - Date.now());
+      await new Promise((r) => setTimeout(r, wait));
+      this.turnBanner = { text };
+      // Fire onReveal (e.g. flip the scorecard to the next player) while the dim
+      // backdrop is fully opaque, so the switch is hidden behind the banner.
+      await new Promise((r) => setTimeout(r, BANNER_REVEAL_MS));
+      opts.onReveal?.();
+      await new Promise((r) => setTimeout(r, Math.max(0, BANNER_TOTAL_MS - BANNER_REVEAL_MS)));
+      this.turnBanner = null;
+      this.turnTransitionActive = false;
+      opts.onDone?.();
     },
 
     // Reset per-turn state for a Puzzle Mode bonus turn (Double Category),

--- a/src/strategies/ai/GreedyStrategy.ts
+++ b/src/strategies/ai/GreedyStrategy.ts
@@ -28,6 +28,18 @@ export class GreedyStrategy {
 
         const potentials = this.scorePotentials(scorecard, dice, canScore, engine);
 
+        // Double Category bonus turn: the engine only accepts the same category
+        // again (summing onto the slot), so pursue it — hold toward it while
+        // rolls remain, otherwise bank it now.
+        const pendingBonus = engine?.getPendingBonusCategory() ?? null;
+        if (pendingBonus !== null) {
+            if (rollsLeft > 0) {
+                const holds = this.computeHolds(dice, pendingBonus);
+                if (holds.some(h => !h)) return { action: 'rollAgain', holds };
+            }
+            return { action: 'pickCategory', category: pendingBonus };
+        }
+
         // Out of rolls — must pick a category.
         if (rollsLeft === 0) {
             return { action: 'pickCategory', category: this.pickBestCategory(potentials, scorecard, canScore) };

--- a/src/styles.css
+++ b/src/styles.css
@@ -728,6 +728,18 @@ body {
     0%, 100% { box-shadow: 0 0 0 1px var(--accent), 0 0 12px -4px var(--accent-soft); }
     50%      { box-shadow: 0 0 0 1px var(--accent), 0 0 22px 2px var(--accent-soft); }
 }
+/* Score bump — brief pop of the chip's score number when it counts up. */
+.player-chip.score-bump .player-score {
+    animation: playerScoreBump 0.5s ease-out;
+}
+@keyframes playerScoreBump {
+    0%   { transform: scale(1); }
+    35%  { transform: scale(1.35); color: #4ade80; }
+    100% { transform: scale(1); }
+}
+@media (prefers-reduced-motion: reduce) {
+    .player-chip.score-bump .player-score { animation: none; }
+}
 .player-avatar {
     width: 32px;
     height: 32px;
@@ -963,18 +975,21 @@ h2 {
 
 /* Yahtzee Animation */
 @keyframes yahtzeeAnimation {
+  /* Keep translate(-50%, -50%) in every step — it provides the horizontal
+     centering off left:50%. Dropping it (as a bare scale()/rotate()) anchors
+     the element's left edge at center and shoots the text off the right. */
   0%, 100% {
-    transform: scale(0.3) rotate(-10deg);
+    transform: translate(-50%, -50%) scale(0.3) rotate(-10deg);
     opacity: 0;
     color: #ffd700;
   }
   25%, 75% {
-    transform: scale(1) rotate(10deg);
+    transform: translate(-50%, -50%) scale(1) rotate(10deg);
     opacity: 1;
     color: #ff4500;
   }
   50% {
-    transform: scale(.75) rotate(0deg);
+    transform: translate(-50%, -50%) scale(.75) rotate(0deg);
     opacity: 1;
     color: #ffd700;
   }
@@ -999,7 +1014,7 @@ h2 {
   letter-spacing: 0.02em;
 }
 @media (prefers-reduced-motion: reduce) {
-  .yahtzee-animation { animation: none; opacity: 1; transform: scale(1) rotate(0); }
+  .yahtzee-animation { animation: none; opacity: 1; transform: translate(-50%, -50%) scale(1) rotate(0); }
   .emoji-animation { animation: none; opacity: 1; transform: translate(-50%, -50%) scale(1); }
   .confetti { display: none; }
 }

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -425,6 +425,28 @@ body.world-cycles .world-fx::after {
     100% { opacity: 0; background-position: -50% 50%; }
 }
 
+/* Floating "+N" that rises above a player's header chip on a score gain. */
+.cell-fx-player-pop {
+    position: fixed;
+    transform: translate(-50%, -50%);
+    font-size: 1.15rem;
+    font-weight: 900;
+    color: #4ade80;
+    text-shadow: 0 1px 4px rgba(0,0,0,0.55), 0 0 10px rgba(74,222,128,0.6);
+    pointer-events: none;
+    white-space: nowrap;
+    animation: cellFxPlayerPop 1.1s cubic-bezier(0.22, 0.61, 0.36, 1) forwards;
+}
+@keyframes cellFxPlayerPop {
+    0%   { opacity: 0; transform: translate(-50%, -10%) scale(0.6); }
+    25%  { opacity: 1; transform: translate(-50%, -90%) scale(1.1); }
+    70%  { opacity: 1; transform: translate(-50%, -150%) scale(1); }
+    100% { opacity: 0; transform: translate(-50%, -220%) scale(0.95); }
+}
+@media (prefers-reduced-motion: reduce) {
+    .cell-fx-player-pop { animation: none; opacity: 1; transform: translate(-50%, -130%); }
+}
+
 /* Ice fragment confetti */
 .cell-fx-ice-fragment {
     position: fixed;

--- a/src/utils/cellAnimations.ts
+++ b/src/utils/cellAnimations.ts
@@ -471,3 +471,24 @@ function positionOver(rect: DOMRect): Partial<CSSStyleDeclaration> {
         height: `${rect.height}px`,
     };
 }
+
+// ---- Player score pop ----
+// A "+N" that rises and fades above a player's header chip when their total
+// climbs, mirroring the cell-level score banner. Anchors to the chip via
+// `[data-player-chip="<index>"]`. The chip's count-up + pulse are handled in
+// GameBoard.vue (Vue-side); this is just the floating delta.
+export function showPlayerScorePop(playerIndex: number, delta: number): void {
+    if (delta <= 0 || typeof document === 'undefined') return;
+    const layer = ensureFxLayer();
+    const chip = document.querySelector<HTMLElement>(`[data-player-chip="${playerIndex}"]`);
+    if (!layer || !chip) return;
+
+    const rect = chip.getBoundingClientRect();
+    const pop = document.createElement('div');
+    pop.className = 'cell-fx-player-pop';
+    pop.textContent = `+${delta}`;
+    pop.style.left = `${rect.left + rect.width / 2}px`;
+    pop.style.top = `${rect.top + 2}px`;
+    layer.appendChild(pop);
+    fade(pop, reducedMotion() ? 700 : 1100);
+}


### PR DESCRIPTION
Add a sequenced multiplayer turn hand-off for local pass-and-play, vs-AI, and online modes:
- Turn banner sweeps in over a dim/blur backdrop announcing the next player, after the finishing player's score animation settles, then hands over control (AI start / timer arm / human unlock). New TurnBanner.vue.
- Defer the scorecard flip to mid-banner so the finishing player's upper- score progression stays visible before the next player's card is revealed.
- Header chip score animates: count-up tween + pulse + floating "+N".

Fixes:
- Yahtzee popup rendered off-screen: keyframe dropped translate(-50%,-50%); every step now keeps it centered.
- Flying Multiplier (x2) jumped the instant you scored: end-of-turn modifier effects now run during the banner (hidden behind the backdrop) for local MP / vs-AI.
- AI could score a still-frozen Ice Block: enforce the canScore veto unconditionally (even on the Double Category bonus path), clear an abandoned pending bonus, and have the AI actually take its bonus turn instead of stranding pendingBonusCategory.